### PR TITLE
Fix timestamps

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -14,8 +14,6 @@ if (token) {
 
 Vue.use(VueRouter);
 
-moment.tz.setDefault(App.timezone);
-
 const router = new VueRouter({
     routes: Routes,
     mode: 'history',

--- a/resources/js/components/Search.vue
+++ b/resources/js/components/Search.vue
@@ -231,7 +231,7 @@ export default {
              * Next, we update some state like the minutes ago selector, and
              * the `searching` that will display the loader.
              */
-            const startTime = moment(this.filters.startTime, 'YYYY-MM-DD LTS').add(new Date().getTimezoneOffset(), 'm');
+            const startTime = moment(this.filters.startTime, 'YYYY-MM-DD LTS');
             this.minutesAgo = parseInt(moment.duration(moment().diff(startTime)).asMinutes());
             this.entries = [];
             this.cursor = null;
@@ -260,7 +260,6 @@ export default {
             let params = { ...this.filters };
             if (this.filters.startTime) {
                 params.startTime = moment(this.filters.startTime, 'YYYY-MM-DD LTS')
-                    .add(new Date().getTimezoneOffset(), 'm')
                     .format('X');
             }
 

--- a/resources/js/components/Search.vue
+++ b/resources/js/components/Search.vue
@@ -259,8 +259,7 @@ export default {
 
             let params = { ...this.filters };
             if (this.filters.startTime) {
-                params.startTime = moment(this.filters.startTime, 'YYYY-MM-DD LTS')
-                    .format('X');
+                params.startTime = moment(this.filters.startTime, 'YYYY-MM-DD LTS').format('X');
             }
 
             this.$router.push({ query: Object.assign({}, this.$route.query, params) }).catch(() => {});


### PR DESCRIPTION
moment.js library is already initializing detecting user timezone (UTC-5 in my case). So, setting `moment.tz.setDefault(App.timezone);` using laravel config timezone, alters the default moment() object and produces an object with the time displaced twice. Calculating the timezone diff and adding it to the startTime value was causing and infinite increment every time the component loads.

I tested this in a brand new laravel 8 installation, and worked ok, detecting my timezone. 