### PR TITLE
Makes Vapor UI middleware customizable

### DIFF
--- a/config/runtime.php
+++ b/config/runtime.php
@@ -1,0 +1,20 @@
+<?php
+
+use Laravel\VaporUi\Support\Cloud;
+
+return [
+    // Aws Credentials
+    'key' => env('AWS_ACCESS_KEY_ID'),
+    'secret' => env('AWS_SECRET_ACCESS_KEY'),
+    'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
+
+    // Vapor Project / CloudWatch Log Group
+    'project' => env('VAPOR_PROJECT', Cloud::project()),
+    'environment' => env('VAPOR_ENVIRONMENT', Cloud::environment()),
+
+    // SQS Queue
+    'queue' => [
+        'prefix' => env('SQS_PREFIX'),
+        'name' => env('SQS_QUEUE'),
+    ],
+];

--- a/config/vapor-ui.php
+++ b/config/vapor-ui.php
@@ -3,60 +3,14 @@
 use Laravel\VaporUi\Http\Middleware\EnsureEnvironmentVariables;
 use Laravel\VaporUi\Http\Middleware\EnsureUpToDateAssets;
 use Laravel\VaporUi\Http\Middleware\EnsureUserIsAuthorized;
-use Laravel\VaporUi\Support\Cloud;
 
 return [
-    /*
-    |--------------------------------------------------------------------------
-    | Vapor Project
-    |--------------------------------------------------------------------------
-    |
-    | Consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore
-    | et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exerci
-    | tation ullamco laboris nisi ut aliquip ex ea commodo consequat du
-    |
-    */
-
-    'project' => env('VAPOR_PROJECT', Cloud::project()),
-    'environment' => env('VAPOR_ENVIRONMENT', Cloud::environment()),
-
-    /*
-    |--------------------------------------------------------------------------
-    | Aws Credentials
-    |--------------------------------------------------------------------------
-    |
-    | Consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore
-    | et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exerci
-    | tation ullamco laboris nisi ut aliquip ex ea commodo consequat du
-    |
-    */
-
-    'key' => env('AWS_ACCESS_KEY_ID'),
-    'secret' => env('AWS_SECRET_ACCESS_KEY'),
-    'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
-
-    /*
-    |--------------------------------------------------------------------------
-    | SQS Queue
-    |--------------------------------------------------------------------------
-    |
-    | Consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore
-    | et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exerci
-    | tation ullamco laboris nisi ut aliquip ex ea commodo consequat du
-    |
-    */
-
-    'queue' => [
-        'prefix' => env('SQS_PREFIX'),
-        'name' => env('SQS_QUEUE'),
-    ],
-
     /*
     |--------------------------------------------------------------------------
     | Vapor UI Route Middleware
     |--------------------------------------------------------------------------
     |
-    | These middleware will be assigned to every Vapor UI route, giving you
+    | These middleware will be assigned to every Vapor UI route - giving you
     | the chance to add your own middleware to this list or change any of
     | the existing middleware. Or, you can simply stick with this list.
     |

--- a/config/vapor-ui.php
+++ b/config/vapor-ui.php
@@ -67,5 +67,5 @@ return [
         EnsureUserIsAuthorized::class,
         EnsureEnvironmentVariables::class,
         EnsureUpToDateAssets::class,
-    ]
+    ],
 ];

--- a/config/vapor-ui.php
+++ b/config/vapor-ui.php
@@ -66,6 +66,6 @@ return [
         'web',
         EnsureUserIsAuthorized::class,
         EnsureEnvironmentVariables::class,
-        EnsureUpToDateAssets::class
+        EnsureUpToDateAssets::class,
     ]
 ];

--- a/config/vapor-ui.php
+++ b/config/vapor-ui.php
@@ -5,6 +5,7 @@ use Laravel\VaporUi\Http\Middleware\EnsureUpToDateAssets;
 use Laravel\VaporUi\Http\Middleware\EnsureUserIsAuthorized;
 
 return [
+
     /*
     |--------------------------------------------------------------------------
     | Vapor UI Route Middleware
@@ -22,4 +23,5 @@ return [
         EnsureEnvironmentVariables::class,
         EnsureUpToDateAssets::class,
     ],
+
 ];

--- a/config/vapor-ui.php
+++ b/config/vapor-ui.php
@@ -1,5 +1,8 @@
 <?php
 
+use Laravel\VaporUi\Http\Middleware\EnsureEnvironmentVariables;
+use Laravel\VaporUi\Http\Middleware\EnsureUpToDateAssets;
+use Laravel\VaporUi\Http\Middleware\EnsureUserIsAuthorized;
 use Laravel\VaporUi\Support\Cloud;
 
 return [
@@ -47,4 +50,22 @@ return [
         'prefix' => env('SQS_PREFIX'),
         'name' => env('SQS_QUEUE'),
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Vapor UI Route Middleware
+    |--------------------------------------------------------------------------
+    |
+    | These middleware will be assigned to every Vapor UI route, giving you
+    | the chance to add your own middleware to this list or change any of
+    | the existing middleware. Or, you can simply stick with this list.
+    |
+    */
+
+    'middleware' => [
+        'web',
+        EnsureUserIsAuthorized::class,
+        EnsureEnvironmentVariables::class,
+        EnsureUpToDateAssets::class
+    ]
 ];

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,16 +7,16 @@ use Laravel\VaporUi\Http\Controllers\JobMetricController;
 use Laravel\VaporUi\Http\Controllers\LogController;
 
 Route::middleware('vapor-ui')->prefix('vapor-ui')->group(function () {
-        Route::get('/api/logs/{group}', [LogController::class, 'index']);
-        Route::get('/api/logs/{group}/{id}', [LogController::class, 'show']);
+    Route::get('/api/logs/{group}', [LogController::class, 'index']);
+    Route::get('/api/logs/{group}/{id}', [LogController::class, 'show']);
 
-        Route::get('/api/jobs/metrics', [JobMetricController::class, 'index']);
+    Route::get('/api/jobs/metrics', [JobMetricController::class, 'index']);
 
-        Route::get('/api/jobs/{group}', [JobController::class, 'index']);
-        Route::get('/api/jobs/{group}/{id}', [JobController::class, 'show']);
+    Route::get('/api/jobs/{group}', [JobController::class, 'index']);
+    Route::get('/api/jobs/{group}/{id}', [JobController::class, 'show']);
 
-        Route::post('/api/jobs/failed/retry/{id}', [JobController::class, 'retry']);
-        Route::post('/api/jobs/failed/forget/{id}', [JobController::class, 'forget']);
+    Route::post('/api/jobs/failed/retry/{id}', [JobController::class, 'retry']);
+    Route::post('/api/jobs/failed/forget/{id}', [JobController::class, 'forget']);
 
-        Route::get('/{view?}', HomeController::class)->where('view', '(.*)')->name('vapor-ui');
-    });
+    Route::get('/{view?}', HomeController::class)->where('view', '(.*)')->name('vapor-ui');
+});

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,17 +5,8 @@ use Laravel\VaporUi\Http\Controllers\HomeController;
 use Laravel\VaporUi\Http\Controllers\JobController;
 use Laravel\VaporUi\Http\Controllers\JobMetricController;
 use Laravel\VaporUi\Http\Controllers\LogController;
-use Laravel\VaporUi\Http\Middleware\EnsureEnvironmentVariables;
-use Laravel\VaporUi\Http\Middleware\EnsureUpToDateAssets;
-use Laravel\VaporUi\Http\Middleware\EnsureUserIsAuthorized;
 
-Route::prefix('vapor-ui')
-    ->middleware([
-        'web',
-        EnsureUserIsAuthorized::class,
-        EnsureEnvironmentVariables::class,
-        EnsureUpToDateAssets::class,
-    ])->group(function () {
+Route::middleware('vapor-ui')->prefix('vapor-ui')->group(function () {
         Route::get('/api/logs/{group}', [LogController::class, 'index']);
         Route::get('/api/logs/{group}/{id}', [LogController::class, 'show']);
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,17 +6,19 @@ use Laravel\VaporUi\Http\Controllers\JobController;
 use Laravel\VaporUi\Http\Controllers\JobMetricController;
 use Laravel\VaporUi\Http\Controllers\LogController;
 
-Route::middleware('vapor-ui')->prefix('vapor-ui')->group(function () {
-    Route::get('/api/logs/{group}', [LogController::class, 'index']);
-    Route::get('/api/logs/{group}/{id}', [LogController::class, 'show']);
+Route::prefix('vapor-ui')
+    ->middleware('vapor-ui')
+    ->group(function () {
+        Route::get('/api/logs/{group}', [LogController::class, 'index']);
+        Route::get('/api/logs/{group}/{id}', [LogController::class, 'show']);
 
-    Route::get('/api/jobs/metrics', [JobMetricController::class, 'index']);
+        Route::get('/api/jobs/metrics', [JobMetricController::class, 'index']);
 
-    Route::get('/api/jobs/{group}', [JobController::class, 'index']);
-    Route::get('/api/jobs/{group}/{id}', [JobController::class, 'show']);
+        Route::get('/api/jobs/{group}', [JobController::class, 'index']);
+        Route::get('/api/jobs/{group}/{id}', [JobController::class, 'show']);
 
-    Route::post('/api/jobs/failed/retry/{id}', [JobController::class, 'retry']);
-    Route::post('/api/jobs/failed/forget/{id}', [JobController::class, 'forget']);
+        Route::post('/api/jobs/failed/retry/{id}', [JobController::class, 'retry']);
+        Route::post('/api/jobs/failed/forget/{id}', [JobController::class, 'forget']);
 
-    Route::get('/{view?}', HomeController::class)->where('view', '(.*)')->name('vapor-ui');
-});
+        Route::get('/{view?}', HomeController::class)->where('view', '(.*)')->name('vapor-ui');
+    });

--- a/src/VaporUiServiceProvider.php
+++ b/src/VaporUiServiceProvider.php
@@ -28,6 +28,10 @@ class VaporUiServiceProvider extends ServiceProvider
 
         if ($this->app->runningInConsole()) {
             $this->publishes([
+                __DIR__.'/../config/vapor-ui.php' => config_path('vapor-ui.php'),
+            ], 'vapor-ui-config');
+
+            $this->publishes([
                 __DIR__.'/../public' => public_path('vendor/vapor-ui'),
             ], 'vapor-ui-assets');
 
@@ -45,6 +49,8 @@ class VaporUiServiceProvider extends ServiceProvider
     public function register()
     {
         $this->mergeConfigFrom(__DIR__.'/../config/vapor-ui.php', 'vapor-ui');
+        $this->mergeConfigFrom(__DIR__.'/../config/runtime.php', 'vapor-ui');
+
         $this->ensureVaporUiIsConfigured();
 
         $this->commands([

--- a/src/VaporUiServiceProvider.php
+++ b/src/VaporUiServiceProvider.php
@@ -6,6 +6,7 @@ use Aws\CloudWatch\CloudWatchClient;
 use Aws\CloudWatchLogs\CloudWatchLogsClient;
 use Aws\Sqs\SqsClient;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 use Laravel\VaporUi\Concerns\ConfiguresVaporUi;
 
@@ -20,6 +21,8 @@ class VaporUiServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        Route::middlewareGroup('vapor-ui', config('vapor-ui.middleware', []));
+
         $this->loadRoutesFrom(__DIR__.'/../routes/web.php');
         $this->loadViewsFrom(__DIR__.'/../resources/views', 'vapor-ui');
 

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -4,4 +4,6 @@ uses(Tests\TestCase::class)
     ->group('integration')
     ->in('Integration');
 
-uses()->group('unit')->in('Unit');
+uses(Tests\TestCase::class)
+    ->group('unit')
+    ->in('Unit');

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -10,6 +10,18 @@ use Orchestra\Testbench\TestCase as OrchestraTestCase;
 abstract class TestCase extends OrchestraTestCase
 {
     /**
+     * Setup the test environment.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->artisan('vapor-ui:publish', ['--force' => true])->run();
+    }
+
+    /**
      * Get package providers.
      *
      * @param \Illuminate\Foundation\Application $app
@@ -18,6 +30,9 @@ abstract class TestCase extends OrchestraTestCase
      */
     protected function getPackageProviders($app)
     {
+        $app->useEnvironmentPath(__DIR__.'/..');
+        $app->bootstrapWith([LoadEnvironmentVariables::class]);
+
         return [VaporUiServiceProvider::class];
     }
 
@@ -30,14 +45,9 @@ abstract class TestCase extends OrchestraTestCase
      */
     protected function getEnvironmentSetUp($app)
     {
-        $app->useEnvironmentPath(__DIR__.'/..');
-        $app->bootstrapWith([LoadEnvironmentVariables::class]);
-
         Gate::define('viewVaporUI', function ($user = null) {
             return true;
         });
-
-        $app['config']->set('vapor-ui', require __DIR__.'./../config/vapor-ui.php');
 
         parent::getEnvironmentSetUp($app);
     }

--- a/tests/Unit/Configuration.php
+++ b/tests/Unit/Configuration.php
@@ -1,0 +1,16 @@
+<?php
+
+test('runtime', function () {
+    expect(config('vapor-ui'))->toHaveKeys([
+        'key',
+        'secret',
+        'region',
+        'project',
+        'environment',
+        'queue',
+    ]);
+});
+
+test('middleware', function () {
+    expect(config('vapor-ui.middleware'))->toBeArray();
+});


### PR DESCRIPTION
This pull request was co-authored by @ugurgungezerler and it adds the possibility of having the Vapor UI middleware stack be overridden at userland - using `config/vapor-ui.php`. Very similar to what we do have in Telescope.

Note that by default, the `vapor-ui:install` Artisan command won't publish the `vapor-ui.php` config file. But the user can easily do it by running `art vendor:publish --tag=vapor-ui-config`. We are going to update docs in this regard.

Closes #13.
This pull request should be squashed.