### PR TITLE
feat: update config to be able to customize Vapor UI uri/path

### DIFF
--- a/config/vapor-ui.php
+++ b/config/vapor-ui.php
@@ -24,4 +24,14 @@ return [
         EnsureUpToDateAssets::class,
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Vapor UI Path
+    |--------------------------------------------------------------------------
+    |
+    | This is the URI path where Vapor UI will be accessible from. Feel free
+    | to change this path to anything you like.
+    |
+    */
+    'path' => env('VAPOR_UI_PATH', 'vapor-ui'),
 ];

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,7 +6,7 @@ use Laravel\VaporUi\Http\Controllers\JobController;
 use Laravel\VaporUi\Http\Controllers\JobMetricController;
 use Laravel\VaporUi\Http\Controllers\LogController;
 
-Route::prefix('vapor-ui')
+Route::prefix(config('vapor-ui.path'))
     ->middleware('vapor-ui')
     ->group(function () {
         Route::get('/api/logs/{group}', [LogController::class, 'index']);

--- a/tests/Unit/Configuration.php
+++ b/tests/Unit/Configuration.php
@@ -14,3 +14,7 @@ test('runtime', function () {
 test('middleware', function () {
     expect(config('vapor-ui.middleware'))->toBeArray();
 });
+
+test('path', function () {
+    expect(config('vapor-ui.path'))->toBeString();
+});


### PR DESCRIPTION
This simple pull request adds a config item `vapor-ui.path` that allows Vapor UI path (URI) to be customized.