### PR TITLE
Retrying failed jobs with retryUntil

### DIFF
--- a/src/Jobs/RetryFailedJob.php
+++ b/src/Jobs/RetryFailedJob.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\VaporUi\Jobs;
 
+use Carbon\CarbonImmutable;
 use Illuminate\Contracts\Queue\Factory;
 use Illuminate\Queue\Failed\FailedJobProviderInterface;
 
@@ -58,6 +59,13 @@ class RetryFailedJob
 
         if (isset($payload['attempts'])) {
             $payload['attempts'] = 0;
+        }
+
+        $retryUntil = $payload['retryUntil'] ?? $payload['timeoutAt'] ?? null;
+        if ($retryUntil) {
+            $payload['retryUntil'] = CarbonImmutable::now()->addSeconds(ceil(
+                    isset($payload['pushedAt']) ? $retryUntil - $payload['pushedAt'] : config('vapor-ui.retry_until', 3600);
+                ))->getTimestamp();
         }
 
         return json_encode($payload);

--- a/src/Jobs/RetryFailedJob.php
+++ b/src/Jobs/RetryFailedJob.php
@@ -63,7 +63,7 @@ class RetryFailedJob
 
         $retryUntil = $payload['retryUntil'] ?? $payload['timeoutAt'] ?? null;
         if ($retryUntil) {
-            $payload['retryUntil'] = CarbonImmutable::now()->addSeconds((int)ceil(
+            $payload['retryUntil'] = CarbonImmutable::now()->addSeconds((int) ceil(
                     isset($payload['pushedAt']) ? $retryUntil - $payload['pushedAt'] : config('vapor-ui.retry_until', 3600)
                 ))->getTimestamp();
         }

--- a/src/Jobs/RetryFailedJob.php
+++ b/src/Jobs/RetryFailedJob.php
@@ -63,7 +63,7 @@ class RetryFailedJob
 
         $retryUntil = $payload['retryUntil'] ?? $payload['timeoutAt'] ?? null;
         if ($retryUntil) {
-            $payload['retryUntil'] = CarbonImmutable::now()->addSeconds(ceil(
+            $payload['retryUntil'] = CarbonImmutable::now()->addSeconds((int)ceil(
                     isset($payload['pushedAt']) ? $retryUntil - $payload['pushedAt'] : config('vapor-ui.retry_until', 3600)
                 ))->getTimestamp();
         }

--- a/src/Jobs/RetryFailedJob.php
+++ b/src/Jobs/RetryFailedJob.php
@@ -64,7 +64,7 @@ class RetryFailedJob
         $retryUntil = $payload['retryUntil'] ?? $payload['timeoutAt'] ?? null;
         if ($retryUntil) {
             $payload['retryUntil'] = CarbonImmutable::now()->addSeconds(ceil(
-                    isset($payload['pushedAt']) ? $retryUntil - $payload['pushedAt'] : config('vapor-ui.retry_until', 3600);
+                    isset($payload['pushedAt']) ? $retryUntil - $payload['pushedAt'] : config('vapor-ui.retry_until', 3600)
                 ))->getTimestamp();
         }
 


### PR DESCRIPTION
Currently, when retrying failed jobs, it would be nice to be able to retry those that have failed due to a retryUntil parameter elapsing.

PR for #38 

