### PR TITLE
Supports environments that switched to docker runtime

### DIFF
--- a/src/Repositories/LogsRepository.php
+++ b/src/Repositories/LogsRepository.php
@@ -126,9 +126,10 @@ class LogsRepository
     protected function logGroupName($group)
     {
         $vaporUi = config('vapor-ui');
+
         $environment = $vaporUi['environment'];
 
-        $switchedToDockerRuntime = Str::endsWith(
+        $usingDockerRuntime = Str::endsWith(
             $_ENV['AWS_LAMBDA_FUNCTION_NAME'] ?? '',
             "$environment-d"
         );
@@ -137,7 +138,7 @@ class LogsRepository
             '/aws/lambda/vapor-%s-%s%s%s',
             $vaporUi['project'],
             $environment,
-            $switchedToDockerRuntime ? '-d' : '',
+            $usingDockerRuntime ? '-d' : '',
             in_array($group, ['cli', 'queue']) ? "-$group" : ''
         );
     }
@@ -186,6 +187,7 @@ class LogsRepository
         }
 
         $query = $filters['query'] ?? '';
+
         $exclude = $this->ignore
             ? '- "'.collect($this->ignore)->implode('" - "').'"'
             : '';

--- a/src/Repositories/LogsRepository.php
+++ b/src/Repositories/LogsRepository.php
@@ -126,11 +126,18 @@ class LogsRepository
     protected function logGroupName($group)
     {
         $vaporUi = config('vapor-ui');
+        $environment = $vaporUi['environment'];
+
+        $switchedToDockerRuntime = Str::endsWith(
+            $_ENV['AWS_LAMBDA_FUNCTION_NAME'] ?? '',
+            "$environment-d"
+        );
 
         return sprintf(
-            '/aws/lambda/vapor-%s-%s%s',
+            '/aws/lambda/vapor-%s-%s%s%s',
             $vaporUi['project'],
-            $vaporUi['environment'],
+            $environment,
+            $switchedToDockerRuntime ? '-d' : '',
             in_array($group, ['cli', 'queue']) ? "-$group" : ''
         );
     }


### PR DESCRIPTION
This pull request fixes an edge case when people switch from a provided runtime to docker images.

When this happens, Vapor appends the "-d" to the lambda function name, so in this pull request, we adapt Vapor UI for that. 