### PR TITLE
Logs/Show link should be a `<a>`, not a `<button>`

### DIFF
--- a/resources/js/screens/logs/index.vue
+++ b/resources/js/screens/logs/index.vue
@@ -19,9 +19,7 @@
                             text-base
                             leading-6
                             border-gray-300
-                            focus:outline-none
-                            focus:shadow-outline-blue
-                            focus:border-blue-300
+                            focus:outline-none focus:shadow-outline-blue focus:border-blue-300
                             sm:text-sm
                             sm:leading-5
                         "
@@ -101,9 +99,7 @@
                             rounded-full
                             bg-transparent
                             hover:text-gray-500
-                            focus:outline-none
-                            focus:text-gray-500
-                            focus:bg-gray-100
+                            focus:outline-none focus:text-gray-500 focus:bg-gray-100
                             transition
                             ease-in-out
                             duration-150

--- a/resources/js/screens/logs/index.vue
+++ b/resources/js/screens/logs/index.vue
@@ -20,8 +20,7 @@
                             leading-6
                             border-gray-300
                             focus:outline-none focus:shadow-outline-blue focus:border-blue-300
-                            sm:text-sm
-                            sm:leading-5
+                            sm:text-sm sm:leading-5
                         "
                     >
                         <option :value="undefined" selected>All</option>

--- a/resources/js/screens/logs/index.vue
+++ b/resources/js/screens/logs/index.vue
@@ -91,8 +91,6 @@
                             params: { id: entry.id, group: entry.group },
                             query: entry.filters,
                         }"
-                        tag="button"
-                        href="#"
                         class="
                             w-8
                             h-8


### PR DESCRIPTION
If it's a `<a>` tag, then users can open the link in a new tab, which they can't do currently.

Related to #54.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
