### PR TITLE
feat: custom queue monitoring

### DIFF
--- a/config/vapor-ui.php
+++ b/config/vapor-ui.php
@@ -24,16 +24,16 @@ return [
         EnsureUpToDateAssets::class,
     ],
 
-   /*
-   |--------------------------------------------------------------------------
-   | Vapor UI Queues
-   |--------------------------------------------------------------------------
-   |
-   | Queue names will be automatically guessed from your vapor.yml config but
-   | you can specify any additional vapor queues in the array below to be
-   | monitored.
-   |
-   */
+    /*
+    |--------------------------------------------------------------------------
+    | Vapor UI Queues
+    |--------------------------------------------------------------------------
+    |
+    | Queue names will be automatically guessed from your vapor.yml config but
+    | you can specify any additional vapor queues in the array below to be
+    | monitored.
+    |
+    */
 
     'queues' => [
 

--- a/config/vapor-ui.php
+++ b/config/vapor-ui.php
@@ -24,4 +24,18 @@ return [
         EnsureUpToDateAssets::class,
     ],
 
+   /*
+   |--------------------------------------------------------------------------
+   | Vapor UI Queues
+   |--------------------------------------------------------------------------
+   |
+   | Queue names will be automatically guessed from your vapor.yml config but
+   | you can specify any additional vapor queues in the array below to be
+   | monitored.
+   |
+   */
+
+    'queues' => [
+
+    ],
 ];

--- a/src/Support/Cloud.php
+++ b/src/Support/Cloud.php
@@ -47,7 +47,7 @@ class Cloud
      */
     public static function queues()
     {
-        return array_merge(self::guessQueues(), config('vapor-ui.queues'));
+        return array_merge(self::guessQueues(), config('vapor-ui.queues', []));
     }
 
     /**

--- a/src/Support/Cloud.php
+++ b/src/Support/Cloud.php
@@ -41,7 +41,7 @@ class Cloud
     }
 
     /**
-     * Get the queue names
+     * Get the queue names to monitor.
      *
      * @return array
      */

--- a/src/Support/Cloud.php
+++ b/src/Support/Cloud.php
@@ -41,11 +41,21 @@ class Cloud
     }
 
     /**
-     * Guesses the queues from the cloud environment.
+     * Get the queue names
      *
      * @return array
      */
     public static function queues()
+    {
+        return array_merge(self::guessQueues(), config('vapor-ui.queues'));
+    }
+
+    /**
+     * Guesses the queues from the cloud environment.
+     *
+     * @return array
+     */
+    public static function guessQueues()
     {
         $prefix = config('vapor-ui.queue.prefix');
 


### PR DESCRIPTION
Currently in vapor you cannot specify a per queue concurrency, each queue in the environment gets same concurrency. A workaround was suggested by vapor staff to deploy into a separate environment, however the issue is we cannot see queue metrics for the queues outside of the main vapor production environment.

This PR adds the ability to specify custom queues in the config file to monitor in addition to the ones grepped from the config file.

Let me know if any changes required and if not i'll also PR the docs
