### PR TITLE
[1.x] Adds Laravel 10.x support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Install PHP dependencies
         run: |
-           composer require "illuminate/contracts=^${{ matrix.laravel }}" --no-update
+           composer require "illuminate/framework=^${{ matrix.laravel }}" --no-update
            composer update --prefer-dist --no-interaction --no-progress
 
       - name: Execute unit tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
           - php: 8.2
             laravel: ^7.0
 
-    name: P${{ matrix.php }} - L${{ matrix.laravel }}
+    name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,6 +37,8 @@ jobs:
             laravel: 6
           - php: 8.2
             laravel: 7
+          - php: 8.2
+            laravel: 8
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,27 +16,11 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.3, 7.4, '8.0', 8.1, 8.2]
-        laravel: [6, 7, 8, 9, 10]
+        php: ['8.0', 8.1, 8.2]
+        laravel: [9, 10]
         exclude:
-          - php: 7.3
-            laravel: 9
-          - php: 7.3
-            laravel: 10
-          - php: 7.4
-            laravel: 9
-          - php: 7.4
-            laravel: 10
           - php: 8.0
             laravel: 10
-          - php: 8.1
-            laravel: 6
-          - php: 8.1
-            laravel: 7
-          - php: 8.2
-            laravel: 6
-          - php: 8.2
-            laravel: 7
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: true
       matrix:
         php: [7.3, 7.4, '8.0', 8.1, 8.2]
-        laravel: [7, 8, 9, 10]
+        laravel: [8, 9, 10]
         exclude:
           - php: 7.3
             laravel: 9
@@ -29,14 +29,6 @@ jobs:
             laravel: 10
           - php: 8.0
             laravel: 10
-          - php: 8.1
-            laravel: 6
-          - php: 8.1
-            laravel: 7
-          - php: 8.2
-            laravel: 6
-          - php: 8.2
-            laravel: 7
           - php: 8.2
             laravel: 8
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,15 +10,41 @@ on:
     - cron: '0 0 * * *'
 
 jobs:
-  linux_tests:
+  tests:
     runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: true
       matrix:
-        php: [7.3, 7.4, '8.0', 8.1, 8.2]
+        php: [7.2, 7.3, 7.4, 8.0, 8.1, 8.2]
+        laravel: [^6.0, ^7.0, ^8.0, ^9.0, ^10.0]
+        exclude:
+          - php: 7.2
+            laravel: ^8.0
+          - php: 7.2
+            laravel: ^9.0
+          - php: 7.2
+            laravel: ^10.0
+          - php: 7.3
+            laravel: ^9.0
+          - php: 7.3
+            laravel: ^10.0
+          - php: 7.4
+            laravel: ^9.0
+          - php: 7.4
+            laravel: ^10.0
+          - php: 8.0
+            laravel: ^10.0
+          - php: 8.1
+            laravel: ^6.0
+          - php: 8.1
+            laravel: ^7.0
+          - php: 8.2
+            laravel: ^6.0
+          - php: 8.2
+            laravel: ^7.0
 
-    name: PHP ${{ matrix.php }}
+    name: P${{ matrix.php }} - L${{ matrix.laravel }}
 
     steps:
       - name: Checkout code
@@ -38,7 +64,9 @@ jobs:
           echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
       - name: Install PHP dependencies
-        run: composer update --prefer-stable --no-interaction --no-progress
+        run: |
+           composer require "illuminate/contracts=${{ matrix.laravel }}" --no-update
+           composer update --prefer-dist --no-interaction --no-progress
 
       - name: Execute unit tests
         run: vendor/bin/pest --colors=always --verbose --group="unit"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,26 +17,26 @@ jobs:
       fail-fast: true
       matrix:
         php: [7.3, 7.4, 8.0, 8.1, 8.2]
-        laravel: [^6.0, ^7.0, ^8.0, ^9.0, ^10.0]
+        laravel: [6, 7, 8, 9, 10]
         exclude:
           - php: 7.3
-            laravel: ^9.0
+            laravel: 9
           - php: 7.3
-            laravel: ^10.0
+            laravel: 10
           - php: 7.4
-            laravel: ^9.0
+            laravel: 9
           - php: 7.4
-            laravel: ^10.0
+            laravel: 10
           - php: 8.0
-            laravel: ^10.0
+            laravel: 10
           - php: 8.1
-            laravel: ^6.0
+            laravel: 6
           - php: 8.1
-            laravel: ^7.0
+            laravel: 7
           - php: 8.2
-            laravel: ^6.0
+            laravel: 6
           - php: 8.2
-            laravel: ^7.0
+            laravel: 7
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 
@@ -59,7 +59,7 @@ jobs:
 
       - name: Install PHP dependencies
         run: |
-           composer require "illuminate/contracts=${{ matrix.laravel }}" --no-update
+           composer require "illuminate/contracts=^${{ matrix.laravel }}" --no-update
            composer update --prefer-dist --no-interaction --no-progress
 
       - name: Execute unit tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: true
       matrix:
         php: [7.3, 7.4, '8.0', 8.1, 8.2]
-        laravel: [6, 7, 8, 9, 10]
+        laravel: [7, 8, 9, 10]
         exclude:
           - php: 7.3
             laravel: 9

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,15 +16,9 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.2, 7.3, 7.4, 8.0, 8.1, 8.2]
+        php: [7.3, 7.4, 8.0, 8.1, 8.2]
         laravel: [^6.0, ^7.0, ^8.0, ^9.0, ^10.0]
         exclude:
-          - php: 7.2
-            laravel: ^8.0
-          - php: 7.2
-            laravel: ^9.0
-          - php: 7.2
-            laravel: ^10.0
           - php: 7.3
             laravel: ^9.0
           - php: 7.3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Install PHP dependencies
         run: |
-           composer require "illuminate/framework=^${{ matrix.laravel }}" --no-update
+           composer require "laravel/framework=^${{ matrix.laravel }}" --no-update
            composer update --prefer-dist --no-interaction --no-progress
 
       - name: Execute unit tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.3, 7.4, 8.0, 8.1, 8.2]
+        php: [7.3, 7.4, '8.0', 8.1, 8.2]
         laravel: [6, 7, 8, 9, 10]
         exclude:
           - php: 7.3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,11 +16,27 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: ['8.0', 8.1, 8.2]
-        laravel: [9, 10]
+        php: [7.3, 7.4, '8.0', 8.1, 8.2]
+        laravel: [6, 7, 8, 9, 10]
         exclude:
+          - php: 7.3
+            laravel: 9
+          - php: 7.3
+            laravel: 10
+          - php: 7.4
+            laravel: 9
+          - php: 7.4
+            laravel: 10
           - php: 8.0
             laravel: 10
+          - php: 8.1
+            laravel: 6
+          - php: 8.1
+            laravel: 7
+          - php: 8.2
+            laravel: 6
+          - php: 8.2
+            laravel: 7
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 

--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,11 @@
     "require": {
         "php": "^7.3|^8.0",
         "aws/aws-sdk-php": "^3.148.3",
-        "laravel/framework": "^7.0|^8.0|^9.0|^10.0",
+        "laravel/framework": "^8.0|^9.0|^10.0",
         "symfony/yaml": "^5.1.4|^6.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^5.0|^6.17.1|^7.0|^8.0",
+        "orchestra/testbench": "^6.17.1|^7.0|^8.0",
         "pestphp/pest": "^1.22.3"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,11 @@
     "require": {
         "php": "^7.3|^8.0",
         "aws/aws-sdk-php": "^3.148.3",
-        "laravel/framework": "^6.0|^7.0|^8.0|^9.0",
+        "laravel/framework": "^6.0|^7.0|^8.0|^9.0|^10.0",
         "symfony/yaml": "^4.3.4|^5.1.4|^6.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^5.0|^6.17.1|^7.0",
+        "orchestra/testbench": "^5.0|^6.17.1|^7.0|^8.0",
         "pestphp/pest": "^1.3"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,13 @@
         }
     ],
     "require": {
-        "php": "^7.3|^8.0",
+        "php": "^8.0",
         "aws/aws-sdk-php": "^3.148.3",
-        "laravel/framework": "^6.0|^7.0|^8.0|^9.0|^10.0",
-        "symfony/yaml": "^4.3.4|^5.1.4|^6.0"
+        "laravel/framework": "^9.0|^10.0",
+        "symfony/yaml": "^6.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^4.0|^5.0|^6.17.1|^7.0|^8.0",
+        "orchestra/testbench": "^7.0|^8.0",
         "pestphp/pest": "^1.3"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "symfony/yaml": "^4.3.4|^5.1.4|^6.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^5.0|^6.17.1|^7.0|^8.0",
+        "orchestra/testbench": "^4.0|^5.0|^6.17.1|^7.0|^8.0",
         "pestphp/pest": "^1.3"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "require-dev": {
         "orchestra/testbench": "^5.0|^6.17.1|^7.0|^8.0",
-        "pestphp/pest": "^1.3"
+        "pestphp/pest": "^1.22.3"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,13 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^7.3|^8.0",
         "aws/aws-sdk-php": "^3.148.3",
-        "laravel/framework": "^9.0|^10.0",
-        "symfony/yaml": "^6.0"
+        "laravel/framework": "^6.0|^7.0|^8.0|^9.0|^10.0",
+        "symfony/yaml": "^4.3.4|^5.1.4|^6.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^7.0|^8.0",
+        "orchestra/testbench": "^4.0|^5.0|^6.17.1|^7.0|^8.0",
         "pestphp/pest": "^1.3"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,11 @@
     "require": {
         "php": "^7.3|^8.0",
         "aws/aws-sdk-php": "^3.148.3",
-        "laravel/framework": "^6.0|^7.0|^8.0|^9.0|^10.0",
-        "symfony/yaml": "^4.3.4|^5.1.4|^6.0"
+        "laravel/framework": "^7.0|^8.0|^9.0|^10.0",
+        "symfony/yaml": "^5.1.4|^6.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^4.0|^5.0|^6.17.1|^7.0|^8.0",
+        "orchestra/testbench": "^5.0|^6.17.1|^7.0|^8.0",
         "pestphp/pest": "^1.3"
     },
     "autoload": {


### PR DESCRIPTION
This pull request adds Laravel 10 support to Vapor UI.

In addition, it drops Laravel 6, and Laravel 7 support.