### PR TITLE
Add laravel-assets for publishing

### DIFF
--- a/src/VaporUiServiceProvider.php
+++ b/src/VaporUiServiceProvider.php
@@ -33,7 +33,7 @@ class VaporUiServiceProvider extends ServiceProvider
 
             $this->publishes([
                 __DIR__.'/../public' => public_path('vendor/vapor-ui'),
-            ], 'vapor-ui-assets');
+            ], ['vapor-ui-assets', 'laravel-assets']);
 
             $this->publishes([
                 __DIR__.'/../stubs/VaporUiServiceProvider.stub' => app_path('Providers/VaporUiServiceProvider.php'),


### PR DESCRIPTION
This adds the `laravel-assets` tag to publish the front-end compiled files whenever a composer update was run for Vapor UI. This is the standard way for Laravel first party packages to publish their compiled files (Horizon, Telescope, Nova, Spark) and will be more easier to use for users instead of having to add a bunch of separate commands.

See https://github.com/laravel/laravel/blob/9.x/composer.json#L41