### PR TITLE
[1.x] Removes `INIT_START` message

### DIFF
--- a/src/Repositories/LogsRepository.php
+++ b/src/Repositories/LogsRepository.php
@@ -24,6 +24,7 @@ class LogsRepository
      */
     protected $ignore = [
         'Creating storage directory',
+        'INIT_START Runtime Version',
         'START RequestId',
         'REPORT RequestId',
         'END RequestId',


### PR DESCRIPTION
This pull request removes an "unnecessary" new message introduced on logs by AWS.