### PR TITLE
[1.x] Removes environment file decryption messages

### DIFF
--- a/src/Repositories/LogsRepository.php
+++ b/src/Repositories/LogsRepository.php
@@ -43,6 +43,8 @@ class LogsRepository
         'Injecting secret',
         'Killing container. Container has processed',
         'Downloading the application vendor archive',
+        'Loading decrypted environment variables.',
+        'Decrypting environment variables.',
     ];
 
     /**


### PR DESCRIPTION
Removes (filters out) the environment file decryption log messages that were added in https://github.com/laravel/vapor-core/pull/140

These messages create a lot of unnecessary noise in the Vapor UI logs.
