### PR TITLE
Add Laravel 11.x support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,14 +31,10 @@ jobs:
             laravel: 10
           - php: 8.2
             laravel: 8
-          - php: 8.2
-            laravel: 11
           - php: 8.3
             laravel: 8
           - php: 8.3
             laravel: 9
-          - php: 8.3
-            laravel: 11
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,3 +66,8 @@ jobs:
 
       - name: Execute unit tests
         run: vendor/bin/pest --colors=always --verbose --group="unit"
+        if: matrix.laravel < 11
+
+      - name: Execute unit tests
+        run: vendor/bin/pest --colors=always --display-errors --group="unit"
+        if: matrix.laravel > 10

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: true
       matrix:
         php: [7.3, 7.4, '8.0', 8.1, 8.2, 8.3]
-        laravel: [8, 9, 10]
+        laravel: [8, 9, 10, 11]
         exclude:
           - php: 7.3
             laravel: 9

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,8 +66,8 @@ jobs:
 
       - name: Execute unit tests
         run: vendor/bin/pest --colors=always --verbose --group="unit"
-        if: matrix.laravel < 11
+        if: ${{ matrix.laravel < 11 }}
 
       - name: Execute unit tests
         run: vendor/bin/pest --colors=always --display-errors --group="unit"
-        if: matrix.laravel > 10
+        if: ${{ matrix.laravel >= 11 }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,10 +31,14 @@ jobs:
             laravel: 10
           - php: 8.2
             laravel: 8
+          - php: 8.2
+            laravel: 11
           - php: 8.3
             laravel: 8
           - php: 8.3
             laravel: 9
+          - php: 8.3
+            laravel: 11
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,6 +35,8 @@ jobs:
             laravel: 10
           - php: 8.0
             laravel: 11
+          - php: 8.1
+            laravel: 11
           - php: 8.2
             laravel: 8
           - php: 8.3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,12 +23,18 @@ jobs:
             laravel: 9
           - php: 7.3
             laravel: 10
+          - php: 7.3
+            laravel: 11
           - php: 7.4
             laravel: 9
           - php: 7.4
             laravel: 10
+          - php: 7.4
+            laravel: 11
           - php: 8.0
             laravel: 10
+          - php: 8.0
+            laravel: 11
           - php: 8.2
             laravel: 8
           - php: 8.3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,9 +65,4 @@ jobs:
            composer update --prefer-dist --no-interaction --no-progress
 
       - name: Execute unit tests
-        run: vendor/bin/pest --colors=always --verbose --group="unit"
-        if: ${{ matrix.laravel < 11 }}
-
-      - name: Execute unit tests
-        run: vendor/bin/pest --colors=always --display-errors --group="unit"
-        if: ${{ matrix.laravel >= 11 }}
+        run: vendor/bin/pest --colors=always --group="unit"

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php": "^7.3|^8.0|^8.2",
         "aws/aws-sdk-php": "^3.148.3",
         "laravel/framework": "^8.0|^9.0|^10.0|^11.0",
-        "symfony/yaml": "^5.1.4|^6.0"
+        "symfony/yaml": "^5.1.4|^6.0|^7.0"
     },
     "require-dev": {
         "orchestra/testbench": "^6.17.1|^7.0|^8.0|^9.0",

--- a/composer.json
+++ b/composer.json
@@ -18,14 +18,14 @@
         }
     ],
     "require": {
-        "php": "^7.3|^8.0",
+        "php": "^7.3|^8.0|^8.2",
         "aws/aws-sdk-php": "^3.148.3",
-        "laravel/framework": "^8.0|^9.0|^10.0",
+        "laravel/framework": "^8.0|^9.0|^10.0|^11.0",
         "symfony/yaml": "^5.1.4|^6.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^6.17.1|^7.0|^8.0",
-        "pestphp/pest": "^1.22.3"
+        "orchestra/testbench": "^6.17.1|^7.0|^8.0|^9.0",
+        "pestphp/pest": "^1.22.3|^2.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Why is this needed?
- Adds support for laravel 11.x

## Significant changes
- Remove `--verbose` flag from test ci